### PR TITLE
add key 'w' to show winner(s) from voting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN wget --no-check-certificate http://openframeworks.cc/versions/v${OF_VERSION}
     mkdir -p /opt/openFrameworks && \
     tar -xzvf of_v${OF_VERSION}_linux64_release.tar.gz -C /opt/openFrameworks --strip-components 1 && \
     /opt/openFrameworks/scripts/linux/ubuntu/install_dependencies.sh -y && \
-    /opt/openFrameworks/scripts/linux/compileOF.sh -j3
+    /opt/openFrameworks/scripts/linux/compileOF.sh -j`nproc`
 
 # Add user that matches host user
 ARG BUILD_UID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04 
 
 ENV TERM=xterm-256color
-ENV OF_VERSION "0.9.8"
+ENV OF_VERSION "0.10.1-patched"
 ENV OF_ROOT "/opt/openFrameworks"
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -14,15 +14,22 @@ RUN apt-get update; \
 	lsb-release \
         libmpg123-dev \
         gstreamer1.0 \
-        gstreamer1.0-plugins-ugly
+        gstreamer1.0-plugins-ugly \
+        ccache \
+        vim \
+        unzip \
+        rsync \
+        git \
+        ca-certificates
 
-# Install OpenFrameworks
-# based off https://openframeworks.cc/setup/raspberrypi/raspberry-pi-getting-started/
-RUN wget --no-check-certificate http://openframeworks.cc/versions/v${OF_VERSION}/of_v${OF_VERSION}_linux64_release.tar.gz && \
-    mkdir -p /opt/openFrameworks && \
-    tar -xzvf of_v${OF_VERSION}_linux64_release.tar.gz -C /opt/openFrameworks --strip-components 1 && \
+# Install openFrameworks for linux64 and linuxarmv6l
+RUN git clone https://github.com/lucasrangit/openFrameworks.git --branch ${OF_VERSION} --single-branch /opt/openFrameworks && \
+    /opt/openFrameworks/scripts/linux/download_libs.sh && \
     /opt/openFrameworks/scripts/linux/ubuntu/install_dependencies.sh -y && \
-    /opt/openFrameworks/scripts/linux/compileOF.sh -j`nproc`
+    /opt/openFrameworks/scripts/linux/compileOF.sh -j`nproc` && \
+    /opt/openFrameworks/scripts/linux/download_libs.sh --platform linuxarmv6l && \
+    /opt/openFrameworks/scripts/ci/linuxarmv6l/install.sh && \
+    TARGET=linuxarmv6l /opt/openFrameworks/scripts/ci/linuxarmv6l/build.sh
 
 # Add user that matches host user
 ARG BUILD_UID=1000
@@ -33,9 +40,7 @@ RUN (test $(getent group $BUILD_GID) || addgroup -gid $BUILD_GID docker) && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/docker
 
 # Build needs write access to /opt/openFrameworks/addons/obj for some reason
-RUN mkdir /opt/openFrameworks/addons/obj && \
-    chown docker. /opt/openFrameworks/addons/obj
+RUN chown docker. /opt/openFrameworks/addons/obj
 
 USER $BUILD_UID
 WORKDIR /home/docker/hackandtell-raspberry
-

--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ Needs http://openframeworks.cc/ to compile.
     make && make run 
     # or use XCode or other IDE to compile
 
-## Host Build with Docker
+## Build
 
-Pass the `--shell` argument to get an interactive shell inside the build container.
+* Pass the `--shell` argument to get an interactive shell inside the build container.
+* Pass the `armv6` argument to build for the armv6 (e.g. Raspberry Pi).
 
 * `./build.sh`
 
 ### Runtime Dependencies
 
-* Ubuntu: `sudo apt install libfreeimage3`
+* Ubuntu 16.04: `sudo apt install libfreeimage3 libglfw3 liburiparser1`
 
 ### Run
 
 * `bin/hackandtell-raspberry`
-

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Needs http://openframeworks.cc/ to compile.
 
 ## Host Build with Docker
 
+Pass the `--shell` argument to get an interactive shell inside the build container.
+
 * `./build.sh`
 
 ### Runtime Dependencies

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ if ! grep -c docker /proc/1/cgroup > /dev/null; then
     image_tag="$(basename $PWD | sed 's/_/-/g' | cut -c 1-40 | tr '[:upper:]' '[:lower:]'):$(git rev-parse --short HEAD)"
     docker build --build-arg BUILD_UID=$(id -u) --build-arg BUILD_GID=$(id -g) --tag local/$image_tag .
     if [[ $1 == "--shell" ]]; then
-        docker run --name $(basename $PWD) -it -v $PWD:/home/docker/$(basename $PWD) local/$image_tag bash
+        docker run --name $(basename $PWD) -it --rm -v $PWD:/home/docker/$(basename $PWD) local/$image_tag bash
     else
         docker run --name $(basename $PWD) --rm -v $PWD:/home/docker/$(basename $PWD) local/$image_tag $0 $*
     fi

--- a/build.sh
+++ b/build.sh
@@ -6,12 +6,18 @@ set -o xtrace
 if ! grep -c docker /proc/1/cgroup > /dev/null; then
     image_tag="$(basename $PWD | sed 's/_/-/g' | cut -c 1-40 | tr '[:upper:]' '[:lower:]'):$(git rev-parse --short HEAD)"
     docker build --build-arg BUILD_UID=$(id -u) --build-arg BUILD_GID=$(id -g) --tag local/$image_tag .
-    if [[ $1 == "--shell" ]]; then
+    if [[ ${1} == "--shell" ]]; then
         docker run --name $(basename $PWD) -it --rm -v $PWD:/home/docker/$(basename $PWD) local/$image_tag bash
     else
-        docker run --name $(basename $PWD) --rm -v $PWD:/home/docker/$(basename $PWD) local/$image_tag $0 $*
+        docker run --name $(basename $PWD) --rm -v $PWD:/home/docker/$(basename $PWD) local/$image_tag "$0" "$*"
     fi
     exit $?
+fi
+
+rm bin/hackandtell-raspberry
+
+if [[ ${1} == "armv6" ]]; then
+    source cross.env
 fi
 
 make -j`nproc`

--- a/build.sh
+++ b/build.sh
@@ -14,5 +14,4 @@ if ! grep -c docker /proc/1/cgroup > /dev/null; then
     exit $?
 fi
 
-make
-
+make -j`nproc`

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ if ! grep -c docker /proc/1/cgroup > /dev/null; then
     exit $?
 fi
 
-rm bin/hackandtell-raspberry
+rm -f bin/hackandtell-raspberry
 
 if [[ ${1} == "armv6" ]]; then
     source cross.env

--- a/cross.env
+++ b/cross.env
@@ -1,0 +1,15 @@
+export TARGET=linuxarmv6l
+export GCC_PREFIX=arm-linux-gnueabihf
+export GST_VERSION=1.0
+export RPI_ROOT=${OF_ROOT}/scripts/ci/$TARGET/raspbian
+export TOOLCHAIN_ROOT=${OF_ROOT}/scripts/ci/$TARGET/rpi_toolchain
+export PLATFORM_OS=Linux
+export PLATFORM_ARCH=armv6l
+export PKG_CONFIG_LIBDIR=${RPI_ROOT}/usr/lib/pkgconfig:${RPI_ROOT}/usr/lib/${GCC_PREFIX}/pkgconfig:${RPI_ROOT}/usr/share/pkgconfig
+export CXX="ccache ${TOOLCHAIN_ROOT}/bin/${GCC_PREFIX}-g++"
+export CC="ccache ${TOOLCHAIN_ROOT}/bin/${GCC_PREFIX}-gcc"
+export AR=${TOOLCHAIN_ROOT}/bin/${GCC_PREFIX}-ar
+export LD=${TOOLCHAIN_ROOT}/bin/${GCC_PREFIX}-ld
+
+# match the flags used the build OF or it will require a recompile
+export CXXFLAGS="${CXXFLAGS} -ftrack-macro-expansion=0"

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -258,7 +258,7 @@ void ofApp::keyPressed(int key){
     if (key == 'w') {
         // if not shown, async HTTP GET winners
         if (!showWinners)
-            ofLoadURLAsync("http://localhost:8080/winners", "async_req"); // FIXME need static IP for bhnt-vote
+            ofLoadURLAsync("http://localhost:80/winners", "async_req"); // FIXME need static IP for bhnt-vote
         // if shown, hide
         showWinners = false;
         return;

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -243,33 +243,40 @@ void ofApp::exit()
 
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
-    if (key == 'h') {
+    switch (key) {
+    case 'h':
+    case 'H':
         isMenuHidden = !isMenuHidden;
-        return;
-    }
-    if (key == 'a') {
+        break;
+    case 'a':
+    case 'A':
         showApplause = !showApplause;
         paused = true;
-    }
-    if (key == 'r') {
+        break;
+    case 'r':
+    case 'R':
         resetButtonPressed();
-        return;
-    }
-    if (key == 'w') {
+        break;
+    case 'w':
+    case 'W':
         // if not shown, async HTTP GET winners
         if (!showWinners)
-            ofLoadURLAsync("http://localhost:80/winners", "async_req"); // FIXME need static IP for bhnt-vote
+            ofLoadURLAsync("http://localhost:80/winners", "async_req");
         // if shown, hide
         showWinners = false;
-        return;
-    }
-    
-    if (key == 'p' || key == ' ') {
+        break;
+    case 'p':
+    case 'P':
+    case ' ':
         paused = !paused;
-    }
-    
-    if (key == 'q') {
+        break;
+    case 'q':
+    case 'Q':
         ofExit();
+        break;
+    default:
+        /* do nothing with unknown keys */
+        break;
     }
 }
 

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -15,6 +15,8 @@ void ofApp::setup(){
 #endif
     ofSetVerticalSync(true);
     resetButton.addListener(this,&ofApp::resetButtonPressed);
+
+    ofSetEscapeQuitsApp(false);
     
     matelightFont.loadFont("OSP-DIN.ttf", 68, true, true, true);
     signsFont.loadFont("OSP-DIN.ttf", 100, true, true, true );

--- a/src/ofApp.h
+++ b/src/ofApp.h
@@ -56,6 +56,7 @@ public:
     bool isMenuHidden;
     bool isTimerRunning;
     ofxToggle showApplause;
+    ofxToggle showCount;
     ofxToggle showWinners;
     int applauseTextColor;
     int applauseBackgroundColor;
@@ -67,4 +68,6 @@ public:
     int millisecondsLeft;
     int lastTime;
     std::string winners;
+    std::string count;
+    ofxToggle queueGetCount;
 };

--- a/src/ofApp.h
+++ b/src/ofApp.h
@@ -29,6 +29,7 @@ public:
 
     void updateTimeLeft();
     void updateMatelight(std::string minutes);
+    void urlResponse(ofHttpResponse & response);
     void drawStringMono(ofTrueTypeFont* font, std::string text, float x, float y, float w);
     void drawApplause();
     void drawCountDown();
@@ -50,21 +51,20 @@ public:
     ofPixels matelightPixels;
     ofPixels matelightSmall;
     ofImage matelightPreview;
-    
     ofxUDPManager udpConnection;
 
     bool isMenuHidden;
     bool isTimerRunning;
     ofxToggle showApplause;
+    ofxToggle showWinners;
     int applauseTextColor;
     int applauseBackgroundColor;
     // buffers for variable strings on the display
     char localTimeStr[100];
     char timeLeftStr[100];
     // application state
-    
     int millisecondsTotal;
     int millisecondsLeft;
     int lastTime;
-    
+    std::string winners;
 };


### PR DESCRIPTION
Add key 'w' to display winner(s) from [BHNT voting app](https://github.com/robotnyc/nodejs-vote-by-mac).

Pressing 'w' will initiate the HTTP GET request in the background and only on success will the
results be shown on the matelight.

Uses `ofLoadURLAsync` to perform HTTP GET to retrieve the JSON list of winners

For example, ["1"] or ["1", "10"] if there's a tie.

Here are some screenshots with the matelight preview.

![winners_1](https://user-images.githubusercontent.com/701818/45931831-ca3deb80-bf73-11e8-84a9-ae02e69100d5.png)

![winners_2](https://user-images.githubusercontent.com/701818/45931832-cca04580-bf73-11e8-9087-9108c634636f.png)

@uwekamper this is just the basics. Is this the right approach? And something the animations could be built on?